### PR TITLE
Improved conversion error handling

### DIFF
--- a/idrcloudclient.js
+++ b/idrcloudclient.js
@@ -36,6 +36,11 @@
                                     if (success) {
                                         success(data);
                                     }
+                                } else if (data.state === "error") {
+                                    clearInterval(poll);
+                                    if (failure) {
+                                        failure("Error during conversion:\n" + req.responseText);
+                                    }
                                 } else {
                                     if (progress) {
                                         progress(data);


### PR DESCRIPTION
If an error is encountered mid conversion, the client continues to poll. Resolve this issue and report the failure to the failure listener